### PR TITLE
#11 Menu, cabeçalho e seções iniciais do site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,9 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: LinguÁgil | 8 e 9 de Junho, 2018
+title: LinguÁgil 2018
+skills: "O maior evento sobre linguagens de programação e metodologias ágeis de Salvador"
+#skills: "Em 2018, o LinguÁgil chega à sua 8º edição! No total, já tivemos 1600 participantes de Salvador e do Brasil, 89 palestras, 21 workshops: muitas horas de conhecimento e muita mão na massa."
 email: linguagil@linguagil.com.br
 description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
@@ -24,7 +26,6 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 keywords: "your keywords, separated by commas"
 twitter_username: linguagil
 github_username:  linguagil
-skills: "Sed dui sapien, sollicitudin sagittis, rutrum iaculis massa."
 meta_author: LinguÁgil
 
 # Exclude from processing.

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,22 +1,24 @@
- <!-- About Section -->
-    <section class="light">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-12 text-center">
-                    <h2>Por que ir no evento?</h2>
-                    <hr class="star-primary">
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-lg-4 col-lg-offset-2">
-                    <p>Em 2018, o LinguÁgil chega à sua 8º edição! No total, já tivemos 1600 participantes de Salvador e do Brasil, 89 palestras, 21 workshops: muitas horas de conhecimento e muita mão na massa.</p>
-                </div>
-                <div class="col-lg-4">
-                    <p>Este ano, o evento será realizado no Institudo de Matemática da UFBA, com o apoio do Departamento de Ciência da Computação.</p>
-                </div>
-                <div class="col-lg-8 col-lg-offset-2 text-center">
-                    {% include enroll.html %}
-                </div>
+<!-- About Section -->
+<section class="light">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <h2>Por que ir no evento?</h2>
+                <hr class="star-primary">
             </div>
         </div>
-    </section>
+        <div class="row">
+            <div class="col-lg-4 col-lg-offset-2">
+                <p>Em 2018, o LinguÁgil chega à sua 8º edição! No total, já tivemos 1600 participantes de Salvador e do
+                    Brasil, 89 palestras, 21 workshops: muitas horas de conhecimento e muita mão na massa.</p>
+            </div>
+            <div class="col-lg-4">
+                <p>Este ano, o evento será realizado no Institudo de Matemática da UFBA, com o apoio do Departamento de
+                    Ciência da Computação.</p>
+            </div>
+            <div class="col-lg-8 col-lg-offset-2 text-center">
+                {% include enroll.html %}
+            </div>
+        </div>
+    </div>
+</section>

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -3,7 +3,7 @@
     <div class="container">
         <div class="row">
             <div class="col-lg-12 text-center">
-                <h2>Por que ir no evento?</h2>
+                <h2>Por que ir ao evento?</h2>
                 <hr class="star-primary">
             </div>
         </div>

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -13,8 +13,8 @@
                     Brasil, 89 palestras, 21 workshops: muitas horas de conhecimento e muita mão na massa.</p>
             </div>
             <div class="col-lg-4">
-                <p>Este ano, o evento será realizado no Institudo de Matemática da UFBA, com o apoio do Departamento de
-                    Ciência da Computação.</p>
+                <p>Será realizado no Instituto de Matemática da UFBA, com o apoio do Departamento de Ciência da Computação.
+                    Objetivo: divulgar novas práticas de engenharia de software e tecnologias.</p>
             </div>
             <div class="col-lg-8 col-lg-offset-2 text-center">
                 {% include enroll.html %}

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -9,12 +9,12 @@
         </div>
         <div class="row">
             <div class="col-lg-4 col-lg-offset-2">
-                <p>Em 2018, o LinguÁgil chega à sua 8º edição! No total, já tivemos 1600 participantes de Salvador e do
-                    Brasil, 89 palestras, 21 workshops: muitas horas de conhecimento e muita mão na massa.</p>
+                <p><strong>O principal objetivo do LinguÁgil é divulgar novas práticas de engenharia de software e tecnologias. </strong>
+                    Faremos isso por meio do debate e da troca de experiências entre especialistas nacionais e da comunidade baiana.</p>
             </div>
             <div class="col-lg-4">
-                <p>Será realizado no Instituto de Matemática da UFBA, com o apoio do Departamento de Ciência da Computação.
-                    Objetivo: divulgar novas práticas de engenharia de software e tecnologias.</p>
+                <p>Em 2018, o LinguÁgil chega à sua 8º edição. No total, já tivemos 1600 participantes de Salvador e do
+                    Brasil, 89 palestras, 21 workshops: muitas horas de conhecimento e muita mão na massa.</p>
             </div>
             <div class="col-lg-8 col-lg-offset-2 text-center">
                 {% include enroll.html %}

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,23 +1,21 @@
  <!-- About Section -->
-    <section class="success">
+    <section class="light">
         <div class="container">
             <div class="row">
                 <div class="col-lg-12 text-center">
-                    <h2>Sobre</h2>
-                    <hr class="star-light">
+                    <h2>Por que ir no evento?</h2>
+                    <hr class="star-primary">
                 </div>
             </div>
             <div class="row">
                 <div class="col-lg-4 col-lg-offset-2">
-                    <p>Freelancer is a free bootstrap theme created by Start Bootstrap. The download includes the complete source files including HTML, CSS, and JavaScript as well as optional LESS stylesheets for easy customization.</p>
+                    <p>Em 2018, o LinguÁgil chega à sua 8º edição! No total, já tivemos 1600 participantes de Salvador e do Brasil, 89 palestras, 21 workshops: muitas horas de conhecimento e muita mão na massa.</p>
                 </div>
                 <div class="col-lg-4">
-                    <p>Whether you're a student looking to showcase your work, a professional looking to attract clients, or a graphic artist looking to share your projects, this template is the perfect starting point! </p>
+                    <p>Este ano, o evento será realizado no Institudo de Matemática da UFBA, com o apoio do Departamento de Ciência da Computação.</p>
                 </div>
                 <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <a href="#" class="btn btn-lg btn-outline">
-                        <i class="fa fa-ticket"></i> Inscreva-se!
-                    </a>
+                    {% include enroll.html %}
                 </div>
             </div>
         </div>

--- a/_includes/c4p.html
+++ b/_includes/c4p.html
@@ -1,0 +1,21 @@
+<!-- About Section -->
+<section id="c4p">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <h2>Submeta palestra</h2>
+                <hr class="star-primary">
+                <p>Mini-curso (4 ou 8 horas), Palestra (30 minutos) ou Light Talking (minutos)</p>
+                <p><strong>Prazo final para submissões: 20 de Maio</strong></p>
+            </div>
+        </div>
+        <br>
+        <div class="row">
+            <div class="col-lg-12 text-center">
+                <a href="#" class="btn btn-lg btn-primary">
+                    <i class="fa fa-bullhorn"></i> Submeta palestra
+                </a>
+            </div>
+        </div>
+    </div>
+</section>

--- a/_includes/c4p.html
+++ b/_includes/c4p.html
@@ -5,7 +5,7 @@
             <div class="col-lg-12 text-center">
                 <h2>Submeta palestra</h2>
                 <hr class="star-primary">
-                <p>Mini-curso (4 ou 8 horas), Palestra (30 minutos) ou Light Talking (minutos)</p>
+                <p>Mini-curso (4 ou 8 horas), Palestra (30 minutos) ou Light Talking (15 minutos)</p>
                 <p><strong>Prazo final para submissões: 20 de Maio</strong></p>
             </div>
         </div>

--- a/_includes/enroll.html
+++ b/_includes/enroll.html
@@ -1,0 +1,8 @@
+<br>
+<div class="row">
+    <div class="col-lg-12">
+        <a href="#" class="btn btn-lg btn-outline">
+            <i class="fa fa-ticket"></i> Inscreva-se!
+        </a>
+    </div>
+</div>

--- a/_includes/enroll.html
+++ b/_includes/enroll.html
@@ -1,7 +1,7 @@
 <br>
 <div class="row">
     <div class="col-lg-12">
-        <a href="#" class="btn btn-lg btn-outline">
+        <a href="#" class="btn btn-lg btn-primary">
             <i class="fa fa-ticket"></i> Inscreva-se!
         </a>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,5 +10,6 @@
                     </div>
                 </div>
             </div>
+            {% include enroll.html %}
         </div>
     </header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,15 +1,15 @@
-    <!-- Header -->
-    <header>
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-12">
-                    <div class="intro-text">
-                        <span class="name">{{ site.title }}</span>
-                        <hr class="star-light">
-                        <span class="skills">{{ site.skills }}</span>
-                    </div>
+<!-- Header -->
+<header>
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="intro-text">
+                    <h1>{{ site.title }}</h1>
+                    <hr class="star-light">
+                    <h2>{{ site.skills }}</h2>
                 </div>
             </div>
-            {% include enroll.html %}
         </div>
-    </header>
+        {% include enroll.html %}
+    </div>
+</header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,8 +5,10 @@
             <div class="col-lg-12">
                 <div class="intro-text">
                     <h1>{{ site.title }}</h1>
-                    <hr class="star-light">
-                    <h2>{{ site.skills }}</h2>
+                    <hr class="star-primary">
+                    <h2>O maior evento sobre linguagens de programação e metodologias ágeis de Salvador</h2>
+                    <h3>8 e 9 de Junho <span>•</span> 9h <span>•</span> No Instituto de Matemática, UBFA</h3>
+                    <!--<h2>{{ site.skills }}</h2>-->
                 </div>
             </div>
         </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -33,10 +33,6 @@
                     <li class="page-scroll">
                         <a href="#support">Apoio e realização</a>
                     </li>
-                    <li class="page-scroll">
-                        <!-- contact_static -->
-                        <a href="#contato">Contato</a>
-                    </li>
                 </ul>
             </div>
             <!-- /.navbar-collapse -->

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -21,15 +21,15 @@
                     <li class="page-scroll">
                         <a href="#c4p">Submeta palestra</a>
                     </li>
-                    <li class="page-scroll">
-                        <a href="#speakers">Palestrantes</a>
-                    </li>
+                    <!--<li class="page-scroll">-->
+                        <!--<a href="#speakers">Palestrantes</a>-->
+                    <!--</li>-->
                     <li class="page-scroll">
                         <a href="#venue">Local</a>
                     </li>
-                    <li class="page-scroll">
-                        <a href="#schedule">Programação</a>
-                    </li>
+                    <!--<li class="page-scroll">-->
+                        <!--<a href="#schedule">Programação</a>-->
+                    <!--</li>-->
                     <li class="page-scroll">
                         <a href="#sponsorship">Patrocínio</a>
                     </li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -13,9 +13,6 @@
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->
-            <style>
-                .navbar-default .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>li>a:focus{color:#18bc9c;background-color:transparent}
-            </style>
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">
                     <li class="hidden">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -13,6 +13,9 @@
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->
+            <style>
+                .navbar-default .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>li>a:focus{color:#18bc9c;background-color:transparent}
+            </style>
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">
                     <li class="hidden">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,6 +19,9 @@
                         <a href="#page-top"></a>
                     </li>
                     <li class="page-scroll">
+                        <a href="#c4p">Submeta palestra</a>
+                    </li>
+                    <li class="page-scroll">
                         <a href="#speakers">Palestrantes</a>
                     </li>
                     <li class="page-scroll">
@@ -31,7 +34,7 @@
                         <a href="#sponsorship">Patrocínio</a>
                     </li>
                     <li class="page-scroll">
-                        <a href="#support">Apoio e realização</a>
+                        <a href="#support">Realização</a>
                     </li>
                 </ul>
             </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -148,17 +148,21 @@ header img {
 }
 
 header .intro-text {
-    h1,h2 {
+    h1,h2,h3 {
         color: $lightest-color;
+    }
+    h2,h3 {
+        font-weight: lighter;
     }
     h1 {
         display: block;
-        font-size: 3.5em;
-        //font-weight: 500;
+        font-size: 3em;
     }
     h2 {
         font-size: 2em;
-        font-weight: lighter;
+    }
+    h3 {
+        font-size: 1.4em;
     }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -321,6 +321,12 @@ section.light {
     }
 }
 
+.btn-primary {
+    color: #ffffff;
+    background-color: $secondary-color;
+    border-color: $secondary-color;
+}
+
 .btn-outline {
     margin-top: 15px;
     border: solid 2px $tertiary-color;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -13,6 +13,7 @@ $secondary-color: #23202B;
 $tertiary-color: #525766;
 $light-color: #9398A3;
 $lighter-color: #D2DEDB;
+$lightest-color: white;
 
 
 // Overrinding boostrap
@@ -93,10 +94,10 @@ hr.star-primary:after {
 
 // Star light
 hr.star-light {
-    border-color: $lighter-color;
+    border-color: $lightest-color;
 }
 hr.star-light:after {
-    color: $lighter-color;
+    color: $lightest-color;
     background-color: $primary-color;
 }
 
@@ -114,6 +115,8 @@ hr.star-primary:after {
     margin: 0 auto;
 }
 
+
+// Header
 header {
     text-align: center;
     color: $tertiary-color;
@@ -135,8 +138,8 @@ header {
 }
 
 header .container {
-    padding-top: 100px;
-    padding-bottom: 0;
+    padding-top: 120px;
+    padding-bottom: 100px;
 }
 
 header img {
@@ -144,16 +147,19 @@ header img {
     margin: 0 auto 20px;
 }
 
-header .intro-text .name {
-    display: block;
-    // text-transform: uppercase;
-    font-size: 2em;
-    font-weight: 500;
-}
-
-header .intro-text .skills {
-    font-size: 1.25em;
-    font-weight: 300;
+header .intro-text {
+    h1,h2 {
+        color: $lightest-color;
+    }
+    h1 {
+        display: block;
+        font-size: 3.5em;
+        //font-weight: 500;
+    }
+    h2 {
+        font-size: 2em;
+        font-weight: lighter;
+    }
 }
 
 @media(min-width:768px) {
@@ -169,15 +175,15 @@ header .intro-text .skills {
 
     header .container {
         padding-top: 180px;
-        padding-bottom: 0;
     }
 
-    header .intro-text .name {
-        font-size: 4.75em;
-    }
-
-    header .intro-text .skills {
-        font-size: 1.75em;
+    header .intro-text {
+        h1 {
+            font-size: 4.75em;
+        }
+        h2 {
+            font-size: 3em;
+        }
     }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -91,15 +91,16 @@ hr.star-primary:after {
     font-size: 2em;
 }
 
+// Star light
 hr.star-light {
-    border-color: $secondary-color;
+    border-color: $lighter-color;
 }
-
 hr.star-light:after {
-    color: $secondary-color;
+    color: $lighter-color;
     background-color: $primary-color;
 }
 
+// Star primary
 hr.star-primary {
     border-color: $secondary-color;
 }
@@ -237,8 +238,12 @@ section h2 {
 }
 
 section.success {
-    color: $tertiary-color;
+    color: $lighter-color;
     background: $primary-color;
+}
+section.light {
+    color: $secondary-color;
+    background: $lighter-color;
 }
 
 @media(max-width:767px) {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -518,9 +518,28 @@ footer .footer-below {
     transform: rotate(90deg);
 }
 
-.navbar-nav>.active>a {
-    background-color: $secondary-color;
+
+.navbar-default {
+    .navbar-nav>.active>a,
+    .navbar-nav>.active>a:hover,
+    .navbar-nav>.active>a:focus {
+        background-color: $tertiary-color;
+    }
 }
+
+.navbar-default {
+    .navbar-brand:hover,
+    .navbar-brand:focus {
+        color: $primary-color;
+        background-color: transparent
+    }
+    .navbar-nav>li>a:hover,
+    .navbar-nav>li>a:focus {
+        color: $primary-color;
+        background-color: transparent
+    }
+}
+
 
 /* Fix modal mouse wheel issues */
 /* https://github.com/twbs/bootstrap/issues/16297 */
@@ -562,3 +581,5 @@ footer .footer-below {
         }
     }
 }
+
+

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -196,6 +196,7 @@ header .intro-text {
     }
 
     .navbar-fixed-top .navbar-brand {
+        padding: 15px 15px;
         font-size: 2em;
         -webkit-transition: all .3s;
         -moz-transition: all .3s;
@@ -526,6 +527,9 @@ footer .footer-below {
         background-color: $tertiary-color;
     }
 }
+
+
+
 
 .navbar-default {
     .navbar-brand:hover,

--- a/index.md
+++ b/index.md
@@ -20,8 +20,9 @@ layout: home
 <body id="page-top" class="index">
 {% include nav.html %}
 {% include header.html %}
-{% include c4p.html %}
 {% include about.html %}
+{% include c4p.html %}
+
 {% include speakers_grid.html %}
 
 <section class="success" id="venue">

--- a/index.md
+++ b/index.md
@@ -20,6 +20,7 @@ layout: home
 <body id="page-top" class="index">
 {% include nav.html %}
 {% include header.html %}
+{% include c4p.html %}
 {% include about.html %}
 {% include speakers_grid.html %}
 

--- a/index.md
+++ b/index.md
@@ -23,8 +23,6 @@ layout: home
 {% include about.html %}
 {% include c4p.html %}
 
-{% include speakers_grid.html %}
-
 <section class="success" id="venue">
     <div class="container">
         <div class="row">
@@ -38,8 +36,6 @@ layout: home
         </div>
     </div>
 </section>
-
-{% include schedule.html %}
 
 <section id="sponsorship">
     <div class="container">


### PR DESCRIPTION
* Corrigi o alinhamento vertical dos itens do menu do topo
* Defini o estilo da chamada principal do site: título do evento + chamada + call to action
* Estilos continuam simples por ora. Mas poderemos completar com imagens e, deus sabe como, com a marca :P

![image](https://user-images.githubusercontent.com/849493/39403094-3b603e80-4b48-11e8-94a9-5cdcb93bec7d.png)
--
* A segunda seção atualmente será a Call 4 papers

![image](https://user-images.githubusercontent.com/849493/39403099-5150950a-4b48-11e8-94c6-bd6d3a931ea1.png)
--
* Deixei pronta a seção complementar à chamada inicial sobre o evento

![image](https://user-images.githubusercontent.com/849493/39403100-58444974-4b48-11e8-8cd8-8237ebba0772.png)
--
* Conteúdo mais importante aparece na primeira tela, sem precisar de scroll, no mobile ou em telas maiores

![image](https://user-images.githubusercontent.com/849493/39403134-f0b9a4f6-4b48-11e8-8c6f-74563596a2e9.png)
--
* Menu continua se comportando bem no mobile após modificações

![image](https://user-images.githubusercontent.com/849493/39403141-25934d4e-4b49-11e8-8972-17484cab60bc.png)