### PR TITLE
Corrige problema com o docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,7 @@
-watch:
-	@docker run --rm --volume="$PWD:/srv/jekyll" -it jekyll/jekyll:3.5 jekyll build --watch
+serve:
+	@docker run --rm \
+		--volume="$$PWD:/srv/jekyll" \
+		--volume="$$PWD/vendor/bundle:/usr/local/bundle" \
+		-p 35729:35729 \
+		-p 4000:4000 \
+		-it jekyll/jekyll:latest jekyll serve --force_polling  --livereload

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Certifique-se de você tem o docker instalado
 
     $ git clone git@github.com:linguagil/2018.git
     $ cd 2018
-    $ make watch
-    
-Abra o arquivo ```2018/_site/index.html```
+    $ make serve
+
+Abra a url: http://0.0.0.0:4000/
 
 ## Como participar da organização
 


### PR DESCRIPTION
Esse PR vai corrigir o uso do docker para servir a aplicação.
Algumas pessoas, assim como eu, estavam reclamando que não estavam conseguindo executar o jekyll e estavam tendo problemas em utilizar o comando do docker.
Atualizei o comando e coloquei para o livereload funcionar.