### PR TITLE
Adiciona uma pequena animação na mudança de tamanho da logo

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -234,6 +234,7 @@ img.event-brand-symbol {
 
 .navbar-fixed-top img.navbar-brand-img {
     width: 120px;
+    transition: width ease-in-out .2s;
 }
 
 @media(min-width:768px) {


### PR DESCRIPTION
Adicionei uma transição de 2 segundos na mudança do tamanho da logo. Estava meio seco a transição entre os tamanhos. Coloquei o mesmo tempo que é utilizado na transição do tamanho do menu.